### PR TITLE
Criação de uma página 404, para diversas questões.

### DIFF
--- a/src/component/App/App.tsx
+++ b/src/component/App/App.tsx
@@ -11,6 +11,7 @@ import TabelaUsuario from '../Usuario/Tabela/TabelaUsuario';
 import VisualizarDocCompleto from '../VisualizarDocCompleto/VisualizarDocCompleto';
 import FormularioUsuario from '../Usuario/FormularioUsuario';
 import UsuarioHome from '../Usuario/UsuarioHome';
+import PaginaNaoEncontrada from '../PaginaNaoEncontrada/PaginaNaoEncontrada';
 
 function App() { 
   return (
@@ -26,6 +27,7 @@ function App() {
           <Route path="/visualizar-documento-completo" element={<VisualizarDocCompleto />} ></Route>
           <Route path="/visualizar-documento/:codigo" element={<VisualizarDoc />} ></Route>
           <Route path="/listar-usuario" element={<UsuarioHome />} ></Route>
+          <Route path="*" element={<PaginaNaoEncontrada/>} ></Route>
         </Routes>
     </div>
     

--- a/src/component/PaginaNaoEncontrada/PaginaNaoEncontrada.css
+++ b/src/component/PaginaNaoEncontrada/PaginaNaoEncontrada.css
@@ -1,0 +1,5 @@
+.AppCenterContext, img{
+    width: 200px;
+    text-align: center;
+    }
+    

--- a/src/component/PaginaNaoEncontrada/PaginaNaoEncontrada.tsx
+++ b/src/component/PaginaNaoEncontrada/PaginaNaoEncontrada.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import Conteudo from "../../compenentes-compartilhados/Conteudo/Conteudo";
+
+    function PaginaNaoEncontrada() {
+
+            return <Conteudo>
+                <div className='AppCenterContext'>
+                <img src="https://static.thenounproject.com/png/1469633-200.png" alt="img: 404" />
+                <h1>Página não encontrada!</h1>
+                <p>Você tentou acessar uma página que não existe.</p>
+                </div>
+                </Conteudo>
+    }
+
+export default PaginaNaoEncontrada


### PR DESCRIPTION
Criação de uma página 404, para avisar ao cliente que o local não existe ou deixou de existir.
    Segue abaixo o resultado:
![Capturar PNG 1](https://github.com/gabrielfilipy/mpu-sp-ui/assets/140566362/c39540c7-102c-49d4-97a1-3a7e411f596e)
