### PR TITLE
ajustando botão de buscar da mesa virtual

### DIFF
--- a/src/component/Mesa/Mesa.css
+++ b/src/component/Mesa/Mesa.css
@@ -3,6 +3,14 @@
     margin-bottom: 20px;
 }
 
+.leftMesa {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    margin-bottom: -35px;
+    max-width: 275px;
+}
+
 .accordion-heading {
     margin-bottom: 8px;
     padding: 10px;

--- a/src/component/Mesa/Mesa.tsx
+++ b/src/component/Mesa/Mesa.tsx
@@ -73,7 +73,7 @@ function Mesa() {
             <div className='HeaderMesa'>
                 <h2>Mesa virtual <FolderCopyIcon /></h2>
 
-                <div className='left'>
+                <div className='leftMesa'>
                     <input onChange={ (e) => setDocumento(e.target.value) }></input>
                     <button onClick={() => buscarDocumentoPelaSigla(documento)}>Buscar</button>
                 </div>


### PR DESCRIPTION
Eu apenas posicionei o botão buscar, que está localizado na mesa virtual,  na esquerda do input de pesquisa, segue imagem de como ficou: 
![Captura de tela 2023-10-10 221637](https://github.com/gabrielfilipy/mpu-sp-ui/assets/140566361/59f78cd2-af1f-43b4-ae54-a131942a98bd)

A mudança do identificador "left" para "leftMesa" foi por conta de um erro que ocorria sempre que eu ajustava o botão buscar, ele acabava quebrando a área de pesquisa do listar usuário, essa pequena mudança agora não interfere mais um no outro.
 