### PR TITLE
erro em funções.tsx

### DIFF
--- a/src/component/VisualizarDoc/Funcoes/Funcoes.tsx
+++ b/src/component/VisualizarDoc/Funcoes/Funcoes.tsx
@@ -7,7 +7,6 @@ import AssinarComCertificadoDigital from '../../AssinarComCertificadoDigital/Ass
 import { deflate } from "zlib";
 import Swal from 'sweetalert2'
 import { Link } from "react-router-dom";
-import Assinar from '../../Assinar/Assinar'; 
 import Incluir from '../../Incluir-Consignatario/Incluir';
 
 declare interface FuncoesProp {


### PR DESCRIPTION
Correção de um import localizado em funções.tsx, segue o antes e depois da correção.

             ANTES:
![correção do erro incluir consignatario sendo passado duas vezes](https://github.com/gabrielfilipy/mpu-sp-ui/assets/140566361/300b082e-f525-4272-b8cd-1eca8e414ef2)



            DEPOIS:
![Captura de tela 2023-10-17 145105](https://github.com/gabrielfilipy/mpu-sp-ui/assets/140566361/861a6049-6220-4aae-94ab-82430e1361c0)


para resolver bastava identificar onde estava localizado o import, que por sinal tinha dois iguais no mesmo componente.

Foi literalmente identificar o erro e descobri a causa que era por conta dos imports repetidos

