### PR TITLE
correção de erro de um hook localizado no cadastrarOrgao.tsx

### DIFF
--- a/src/component/CadastrarOrgao/CadastrarOrgao.tsx
+++ b/src/component/CadastrarOrgao/CadastrarOrgao.tsx
@@ -19,7 +19,6 @@ function CadastrarOrgao() {
 
     const [ cadastrados, setCadastros ] = useState([])
     const [ cadastro, setCadastro ] = useState('')
-    const [ opcao, setOpcao ] = useState('')
     
     
     async function fetchData() {


### PR DESCRIPTION
Segue provas do que foi removido:

![Captura de tela 2023-10-23 214942](https://github.com/gabrielfilipy/mpu-sp-ui/assets/140566361/c2c55880-0fc0-4429-ba22-3dd06aacf3e2)

O hook não estava sendo utilizado nem o opção e nem o setopção
